### PR TITLE
Let our `plone.app.registry` import step depend on `typeinfo`.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,13 @@ Changelog
 1.3.6 (unreleased)
 ------------------
 
+- Let our ``plone.app.registry`` import step depend on ``typeinfo``.
+  The portal types may be needed for vocabularies.  For example, you
+  could get an error when adding a not yet installed type to
+  ``types_not_searched``.
+  Fixes https://github.com/plone/Products.CMFPlone/issues/1118
+  [maurits]
+
 - show loading icon in control panel when searching
   [vangheem]
 

--- a/plone/app/registry/exportimport/configure.zcml
+++ b/plone/app/registry/exportimport/configure.zcml
@@ -15,6 +15,7 @@
         handler=".handler.importRegistry">
         <depends name="componentregistry"/>
         <depends name="toolset"/>
+        <depends name="typeinfo"/>
     </gs:importStep>
 
     <gs:exportStep


### PR DESCRIPTION
The portal types may be needed for vocabularies.  For example, you
could get an error when adding a not yet installed type to
`types_not_searched`.

Fixes https://github.com/plone/Products.CMFPlone/issues/1118