### PR TITLE
Overview control panel url from context

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,9 @@ Incompatibilities:
 
 New:
 
-- *add item here*
+- Let the ``RegistryEditForm`` construct the base url to the ``@@overview-controlpanel`` from the context URL instead the portal URL.
+  This gives more flexibility when calling controlpanels on contexts with local registries while in standard Plone installations the controlpanel is still bound to the portal url.
+  [thet]
 
 Fixes:
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,9 +10,8 @@ Incompatibilities:
 
 New:
 
-- Let the ``ControlPanelFormWrapper`` construct the base url to the ``@@overview-controlpanel`` from the context URL instead the portal URL.
-  For the ``@@configuration_registry``, construct the base url to the ``@@overview-controlpanel`` from the nearest site.
-  This gives more flexibility when calling controlpanels on contexts with local registries while in standard Plone installations the controlpanel is still bound to the portal url.
+- For ``ControlPanelFormWrapper`` and ``@@configuration_registry``, construct the base url to the ``@@overview-controlpanel`` from the nearest site.
+  This gives more flexibility when calling controlpanels on sub sites with local registries while in standard Plone installations the controlpanel is still bound to the portal url.
   [thet]
 
 Fixes:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,8 @@ Incompatibilities:
 
 New:
 
-- Let the ``RegistryEditForm`` construct the base url to the ``@@overview-controlpanel`` from the context URL instead the portal URL.
+- Let the ``ControlPanelFormWrapper`` construct the base url to the ``@@overview-controlpanel`` from the context URL instead the portal URL.
+  For the ``@@configuration_registry``, construct the base url to the ``@@overview-controlpanel`` from the nearest site.
   This gives more flexibility when calling controlpanels on contexts with local registries while in standard Plone installations the controlpanel is still bound to the portal url.
   [thet]
 

--- a/plone/app/registry/browser/controlpanel.py
+++ b/plone/app/registry/browser/controlpanel.py
@@ -69,14 +69,20 @@ class RegistryEditForm(AutoExtensibleForm, form.EditForm):
         IStatusMessage(self.request).addStatusMessage(
             _(u"Changes canceled."),
             "info")
-        self.request.response.redirect("%s/%s" % (
+        self.request.response.redirect(u"{0}/{1}".format(
             self.context.absolute_url(),
-            self.control_panel_view))
+            self.control_panel_view
+        ))
 
 
 class ControlPanelFormWrapper(layout.FormWrapper):
     """Use this form as the plone.z3cform layout wrapper to get the control
     panel layout.
     """
-
     index = ViewPageTemplateFile('controlpanel_layout.pt')
+
+    @property
+    def control_panel_url(self):
+        return u"{0}/@@overview-controlpanel".format(
+            self.context.absolute_url()
+        )

--- a/plone/app/registry/browser/controlpanel.py
+++ b/plone/app/registry/browser/controlpanel.py
@@ -10,7 +10,9 @@ from plone.autoform.form import AutoExtensibleForm
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from Products.statusmessages.interfaces import IStatusMessage
 
+from zope.component.hooks import getSite
 from zope.i18nmessageid import MessageFactory
+
 _ = MessageFactory('plone')
 
 
@@ -70,7 +72,7 @@ class RegistryEditForm(AutoExtensibleForm, form.EditForm):
             _(u"Changes canceled."),
             "info")
         self.request.response.redirect(u"{0}/{1}".format(
-            self.context.absolute_url(),
+            getSite().absolute_url(),
             self.control_panel_view
         ))
 
@@ -83,6 +85,4 @@ class ControlPanelFormWrapper(layout.FormWrapper):
 
     @property
     def control_panel_url(self):
-        return u"{0}/@@overview-controlpanel".format(
-            self.context.absolute_url()
-        )
+        return u"{0}/@@overview-controlpanel".format(getSite().absolute_url())

--- a/plone/app/registry/browser/controlpanel_layout.pt
+++ b/plone/app/registry/browser/controlpanel_layout.pt
@@ -10,7 +10,7 @@
 <div metal:fill-slot="prefs_configlet_main">
 
     <a id="setup-link" class="link-parent"
-       tal:attributes="href string:$portal_url/@@overview-controlpanel"
+       tal:attributes="href view/control_panel_url"
        i18n:translate="">
         Site Setup
     </a>

--- a/plone/app/registry/browser/records.pt
+++ b/plone/app/registry/browser/records.pt
@@ -19,9 +19,9 @@
   tal:define="records view/records">
 
     <a id="setup-link" class="link-parent"
-       tal:attributes="href string:$portal_url/@@overview-controlpanel"
+       tal:attributes="href view/control_panel_url"
        i18n:translate="">
-       Site Setup
+        Site Setup
     </a>
 
     <h1 class="documentFirstHeading" i18n:translate="heading_registry">Configuration Registry</h1>

--- a/plone/app/registry/browser/records.py
+++ b/plone/app/registry/browser/records.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from Products.CMFPlone.PloneBatch import Batch
 from Products.Five import BrowserView
+from zope.component.hooks import getSite
 
 
 def _true(s, v):
@@ -22,6 +23,12 @@ _okay_prefixes = [
 
 
 class RecordsControlPanel(BrowserView):
+
+    @property
+    def control_panel_url(self):
+        return u"{0}/@@overview-controlpanel".format(
+            getSite().absolute_url()
+        )
 
     def __call__(self):
         form = self.request.form

--- a/plone/app/registry/browser/records.py
+++ b/plone/app/registry/browser/records.py
@@ -26,9 +26,7 @@ class RecordsControlPanel(BrowserView):
 
     @property
     def control_panel_url(self):
-        return u"{0}/@@overview-controlpanel".format(
-            getSite().absolute_url()
-        )
+        return u"{0}/@@overview-controlpanel".format(getSite().absolute_url())
 
     def __call__(self):
         form = self.request.form

--- a/plone/app/registry/tests/test_controlpanel.py
+++ b/plone/app/registry/tests/test_controlpanel.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from plone.app.registry.browser.controlpanel import ControlPanelFormWrapper
+from plone.app.registry.browser.records import RecordsControlPanel
 from plone.app.registry.testing import PLONE_APP_REGISTRY_INTEGRATION_TESTING
 
 import types
@@ -24,4 +25,19 @@ class TestRegistryBaseControlpanel(unittest.TestCase):
         self.assertEqual(
             view.control_panel_url,
             u'http://nohost/noportal/nocontext/@@overview-controlpanel'
+        )
+
+
+class TestRecordsControlPanel(unittest.TestCase):
+
+    layer = PLONE_APP_REGISTRY_INTEGRATION_TESTING
+
+    def test_records_control_panel__control_panel_url(self):
+        """Test, if control_panel_url property of the registry controlpanel
+        returns the correct url.
+        """
+        view = RecordsControlPanel(None, None)
+        self.assertEqual(
+            view.control_panel_url,
+            u'http://nohost/plone/@@overview-controlpanel'
         )

--- a/plone/app/registry/tests/test_controlpanel.py
+++ b/plone/app/registry/tests/test_controlpanel.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from plone.app.registry.browser.controlpanel import ControlPanelFormWrapper
+from plone.app.registry.testing import PLONE_APP_REGISTRY_INTEGRATION_TESTING
+
+import types
+import unittest2 as unittest
+
+
+class TestRegistryBaseControlpanel(unittest.TestCase):
+
+    layer = PLONE_APP_REGISTRY_INTEGRATION_TESTING
+
+    def test_registry_base_controlpanel__control_panel_url(self):
+        """Test, if control_panel_url property of the base controlpanel returns
+        the correct url.
+        """
+        # Mock context
+        context = type('Dummy', (object,), {})
+        context.absolute_url = types.MethodType(
+            lambda self: 'http://nohost/noportal/nocontext',
+            context
+        )
+        view = ControlPanelFormWrapper(context, None)
+        self.assertEqual(
+            view.control_panel_url,
+            u'http://nohost/noportal/nocontext/@@overview-controlpanel'
+        )

--- a/plone/app/registry/tests/test_controlpanel.py
+++ b/plone/app/registry/tests/test_controlpanel.py
@@ -15,16 +15,10 @@ class TestRegistryBaseControlpanel(unittest.TestCase):
         """Test, if control_panel_url property of the base controlpanel returns
         the correct url.
         """
-        # Mock context
-        context = type('Dummy', (object,), {})
-        context.absolute_url = types.MethodType(
-            lambda self: 'http://nohost/noportal/nocontext',
-            context
-        )
-        view = ControlPanelFormWrapper(context, None)
+        view = ControlPanelFormWrapper(None, None)
         self.assertEqual(
             view.control_panel_url,
-            u'http://nohost/noportal/nocontext/@@overview-controlpanel'
+            u'http://nohost/plone/@@overview-controlpanel'
         )
 
 


### PR DESCRIPTION
Let the ``RegistryEditForm`` construct the base url to the ``@@overview-controlpanel`` from the context URL instead the portal URL.
This gives more flexibility when calling controlpanels on contexts with local registries while in standard Plone installations the controlpanel is still bound to the portal url.