### PR TITLE
Add support for import conditions in registry.xml records

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,8 +1,8 @@
 Changelog
 =========
 
-1.3.13 (unreleased)
--------------------
+1.4.0 (unreleased)
+------------------
 
 Breaking changes:
 
@@ -10,7 +10,10 @@ Breaking changes:
 
 New features:
 
-- *add item here*
+- Add support for optional condition attribute in registry.xml entries
+  to allow conditional importing of records. Conditions themselves are
+  not import (nor exported).
+  [datakurre]
 
 Bug fixes:
 

--- a/README.rst
+++ b/README.rst
@@ -157,6 +157,32 @@ pairs. They can be configured like so::
         </value>
     </record>
 
+
+Conditional records
+~~~~~~~~~~~~~~~~~~~
+
+Importable records in ``registry.xml`` can be marked conditional with
+``condition`` attribute, which supports the following condition values:
+
+* ``installed my.package``, which causes record to be imported only when
+  python module ``my.package`` is available to be imported.
+
+* ``not-installed my.package``, which causes record to be imported only when
+  python module ``my.package`` is *not* available to be imported:
+
+For example, the following ``registry.xml`` step at the GenericSetup profile of
+your policy product, would only import records when module ``my.package`` is
+available::
+
+    <registry>
+      <records interface="my.package.interfaces.IZooSettings"
+               condition="installed my.package">
+        <value key="entryPrice">40</value>
+        <value key="messageOfTheDay">We've got lions and tigers!</value>
+      </records>
+    </registry>
+
+
 Field references
 ~~~~~~~~~~~~~~~~
 

--- a/plone/app/registry/exportimport/handler.py
+++ b/plone/app/registry/exportimport/handler.py
@@ -31,24 +31,24 @@ def evaluateCondition(expression):
     arguments = expression.split(None)
     verb = arguments.pop(0)
 
-    if verb in ('installed', 'not-installed'):
-        if not arguments:
-            raise ValueError("Package name missing: %r" % expression)
-        if len(arguments) > 1:
-            raise ValueError("Only one package allowed: %r" % expression)
-
-        try:
-            __import__(arguments[0])
-            installed = True
-        except ImportError:
-            installed = False
-
-        if verb == 'installed':
-            return installed
-        elif verb == 'not-installed':
-            return not installed
-    else:
+    if verb not in ('installed', 'not-installed'):
         raise ValueError("Invalid import condition: %r" % expression)
+
+    if not arguments:
+        raise ValueError("Package name missing: %r" % expression)
+    if len(arguments) > 1:
+        raise ValueError("Only one package allowed: %r" % expression)
+
+    try:
+        __import__(arguments[0])
+        installed = True
+    except ImportError:
+        installed = False
+
+    if verb == 'installed':
+        return installed
+    elif verb == 'not-installed':
+        return not installed
 
 
 def shouldPurgeList(value_node, key):

--- a/plone/app/registry/tests/test_exportimport.py
+++ b/plone/app/registry/tests/test_exportimport.py
@@ -339,17 +339,6 @@ class TestImport(ExportImportTest):
 
         self.assertRaises(ImportError, importRegistry, context)
 
-    def test_import_records_nonexistant_interface_condition_skip(self):
-        xml = """\
-<registry>
-    <records interface="non.existant.ISchema"
-             condition="installed non" />
-</registry>
-"""
-        context = DummyImportContext(self.site, purge=False)
-        context._files = {'registry.xml': xml}
-        importRegistry(context)
-
     def test_import_value_only(self):
         xml = """\
 <registry>
@@ -373,6 +362,33 @@ class TestImport(ExportImportTest):
         )
         self.assertEquals(
             u"Imported value",
+            self.registry['test.export.simple']
+        )
+
+    def test_import_value_only_condition_skip(self):
+        xml = """\
+<registry>
+    <record name="test.export.simple"
+            condition="installed non">
+        <value>Imported value</value>
+    </record>
+</registry>
+"""
+        context = DummyImportContext(self.site, purge=False)
+        context._files = {'registry.xml': xml}
+
+        self.registry.records['test.export.simple'] = \
+            Record(field.TextLine(title=u"Simple record", default=u"N/A"),
+                   value=u"Sample value")
+        importRegistry(context)
+
+        self.assertEquals(1, len(self.registry.records))
+        self.assertEquals(
+            u"Simple record",
+            self.registry.records['test.export.simple'].field.title
+        )
+        self.assertEquals(
+            u"Sample value",
             self.registry['test.export.simple']
         )
 

--- a/plone/app/registry/tests/test_exportimport.py
+++ b/plone/app/registry/tests/test_exportimport.py
@@ -316,6 +316,40 @@ class TestImport(ExportImportTest):
             42
         )
 
+    def test_import_records_nonexistant_interface(self):
+        xml = """\
+<registry>
+    <records interface="non.existant.ISchema" />
+</registry>
+"""
+        context = DummyImportContext(self.site, purge=False)
+        context._files = {'registry.xml': xml}
+
+        self.assertRaises(ImportError, importRegistry, context)
+
+    def test_import_records_nonexistant_interface_condition(self):
+        xml = """\
+<registry>
+    <records interface="non.existant.ISchema"
+             condition="not-installed non" />
+</registry>
+"""
+        context = DummyImportContext(self.site, purge=False)
+        context._files = {'registry.xml': xml}
+
+        self.assertRaises(ImportError, importRegistry, context)
+
+    def test_import_records_nonexistant_interface_condition_skip(self):
+        xml = """\
+<registry>
+    <records interface="non.existant.ISchema"
+             condition="installed non" />
+</registry>
+"""
+        context = DummyImportContext(self.site, purge=False)
+        context._files = {'registry.xml': xml}
+        importRegistry(context)
+
     def test_import_value_only(self):
         xml = """\
 <registry>

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import find_packages
 from setuptools import setup
 
-version = '1.3.13.dev0'
+version = '1.4.0.dev0'
 
 setup(
     name='plone.app.registry',


### PR DESCRIPTION
To be honest, the main motivation here is to keep some of our products Plone 4 compatible for some time by making it possible to skip import or resource registry records with ``condition="installed Products.CMFPlone.interfaces.resources``.

Sematics and code for *installed* and *not-installed* -conditions are from zope.configuration.

This should be fully backward compatible, but semver would require new feature version.