### PR TITLE
Add support for have and not-have import conditions on Zope2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,9 @@ Breaking changes:
 
 New features:
 
-- *add item here*
+- Add support for *have* and *have-not* import conditions in
+  registry.xml
+  [datakurre]
 
 Bug fixes:
 

--- a/README.rst
+++ b/README.rst
@@ -170,6 +170,12 @@ Importable records in ``registry.xml`` can be marked conditional with
 * ``not-installed my.package``, which causes record to be imported only when
   python module ``my.package`` is *not* available to be imported:
 
+* ``have my-feature``, which causes record to be imported only when
+  ZCML feature flag ``my-feature`` has been registered (Zope2 only)
+
+* ``not-have my-feature``, which causes record to be imported only when
+  ZCML feature flag ``my-feature`` has *not* been registered (Zope2 only)
+
 For example, the following ``registry.xml`` step at the GenericSetup profile of
 your policy product, would only import records when module ``my.package`` is
 available::

--- a/plone/app/registry/tests/test_exportimport.py
+++ b/plone/app/registry/tests/test_exportimport.py
@@ -15,14 +15,15 @@ from plone.supermodel.utils import prettyXML
 from plone.testing import zca
 from Products.GenericSetup.tests.common import DummyExportContext
 from Products.GenericSetup.tests.common import DummyImportContext
-from StringIO import StringIO
 from zope.component import provideUtility
 from zope.configuration import xmlconfig
 from zope.interface import alsoProvides
 import unittest2 as unittest
 
 configuration = """\
-<configure xmlns="http://namespaces.zope.org/zope">
+<configure xmlns="http://namespaces.zope.org/zope"
+           xmlns:meta="http://namespaces.zope.org/meta">
+    <meta:provides feature="plone" />
     <include package="zope.component" file="meta.zcml" />
     <include package="plone.registry" />
     <include package="plone.app.registry.exportimport" file="handlers.zcml" />
@@ -38,7 +39,20 @@ class ExportImportTest(unittest.TestCase):
         self.site = ObjectManager('plone')
         self.registry = Registry('portal_registry')
         provideUtility(provides=IRegistry, component=self.registry)
-        xmlconfig.xmlconfig(StringIO(configuration))
+        context = xmlconfig.string(configuration, execute=True)
+        try:
+            import Zope2.App.zcml
+            self._context = Zope2.App.zcml._context
+            Zope2.App.zcml._context = context
+        except ImportError:
+            pass
+
+    def tearDown(self):
+        try:
+            import Zope2.App.zcml
+            Zope2.App.zcml._context = self._context
+        except ImportError:
+            pass
 
     def assertXmlEquals(self, expected, actual):
 
@@ -327,7 +341,7 @@ class TestImport(ExportImportTest):
 
         self.assertRaises(ImportError, importRegistry, context)
 
-    def test_import_records_nonexistant_interface_condition(self):
+    def test_import_records_nonexistant_interface_condition_not_installed(self):  # noqa
         xml = """\
 <registry>
     <records interface="non.existant.ISchema"
@@ -365,11 +379,65 @@ class TestImport(ExportImportTest):
             self.registry['test.export.simple']
         )
 
-    def test_import_value_only_condition_skip(self):
+    def test_import_value_only_condition_installed(self):
         xml = """\
 <registry>
     <record name="test.export.simple"
             condition="installed non">
+        <value>Imported value</value>
+    </record>
+</registry>
+"""
+        context = DummyImportContext(self.site, purge=False)
+        context._files = {'registry.xml': xml}
+
+        self.registry.records['test.export.simple'] = \
+            Record(field.TextLine(title=u"Simple record", default=u"N/A"),
+                   value=u"Sample value")
+        importRegistry(context)
+
+        self.assertEquals(1, len(self.registry.records))
+        self.assertEquals(
+            u"Simple record",
+            self.registry.records['test.export.simple'].field.title
+        )
+        self.assertEquals(
+            u"Sample value",
+            self.registry['test.export.simple']
+        )
+
+    def test_import_value_only_condition_have(self):
+        xml = """\
+<registry>
+    <record name="test.export.simple"
+            condition="have plone">
+        <value>Imported value</value>
+    </record>
+</registry>
+"""
+        context = DummyImportContext(self.site, purge=False)
+        context._files = {'registry.xml': xml}
+
+        self.registry.records['test.export.simple'] = \
+            Record(field.TextLine(title=u"Simple record", default=u"N/A"),
+                   value=u"Sample value")
+        importRegistry(context)
+
+        self.assertEquals(1, len(self.registry.records))
+        self.assertEquals(
+            u"Simple record",
+            self.registry.records['test.export.simple'].field.title
+        )
+        self.assertEquals(
+            u"Imported value",
+            self.registry['test.export.simple']
+        )
+
+    def test_import_value_only_condition_not_have(self):
+        xml = """\
+<registry>
+    <record name="test.export.simple"
+            condition="not-have plone">
         <value>Imported value</value>
     </record>
 </registry>


### PR DESCRIPTION
This pull would complete by previous pull on conditions with implementation fulfilling PLIP https://github.com/plone/Products.CMFPlone/issues/1406

Yet, a warning: To be able to support conditions *have* and *not-have*, this pull adds Zope2 only features for plone.app.registry. I'm not completely sure about this, but decided to create this pull, because that PLIP was already approved.