### PR TITLE
Backport PLIP 1406 for plone.app.registry 1.2.x

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,20 @@ Changelog
 1.2.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+Breaking changes:
+
+- *add item here*
+
+New features:
+
+- Add support for optional condition attribute in registry.xml entries
+  to allow conditional importing of records. Conditions themselves are
+  not import (nor exported).
+  [datakurre]
+
+Bug fixes:
+
+- *add item here*
 
 
 1.2.4 (2015-05-04)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,20 +4,16 @@ Changelog
 1.2.5 (unreleased)
 ------------------
 
-Breaking changes:
-
-- *add item here*
-
 New features:
+
+- Add support for *have* and *have-not* import conditions in
+  registry.xml
+  [datakurre]
 
 - Add support for optional condition attribute in registry.xml entries
   to allow conditional importing of records. Conditions themselves are
   not import (nor exported).
   [datakurre]
-
-Bug fixes:
-
-- *add item here*
 
 
 1.2.4 (2015-05-04)

--- a/README.rst
+++ b/README.rst
@@ -172,6 +172,12 @@ Importable records in ``registry.xml`` can be marked conditional with
 * ``not-installed my.package``, which causes record to be imported only when
   python module ``my.package`` is *not* available to be imported:
 
+* ``have my-feature``, which causes record to be imported only when
+  ZCML feature flag ``my-feature`` has been registered (Zope2 only)
+
+* ``not-have my-feature``, which causes record to be imported only when
+  ZCML feature flag ``my-feature`` has *not* been registered (Zope2 only)
+
 For example, the following ``registry.xml`` step at the GenericSetup profile of
 your policy product, would only import records when module ``my.package`` is
 available::

--- a/README.rst
+++ b/README.rst
@@ -159,6 +159,32 @@ pairs. They can be configured like so::
         </value>
     </record>
 
+
+Conditional records
+~~~~~~~~~~~~~~~~~~~
+
+Importable records in ``registry.xml`` can be marked conditional with
+``condition`` attribute, which supports the following condition values:
+
+* ``installed my.package``, which causes record to be imported only when
+  python module ``my.package`` is available to be imported.
+
+* ``not-installed my.package``, which causes record to be imported only when
+  python module ``my.package`` is *not* available to be imported:
+
+For example, the following ``registry.xml`` step at the GenericSetup profile of
+your policy product, would only import records when module ``my.package`` is
+available::
+
+    <registry>
+      <records interface="my.package.interfaces.IZooSettings"
+               condition="installed my.package">
+        <value key="entryPrice">40</value>
+        <value key="messageOfTheDay">We've got lions and tigers!</value>
+      </records>
+    </registry>
+
+
 Field references
 ~~~~~~~~~~~~~~~~
 

--- a/plone/app/registry/exportimport/handler.py
+++ b/plone/app/registry/exportimport/handler.py
@@ -33,24 +33,24 @@ def evaluateCondition(expression):
     arguments = expression.split(None)
     verb = arguments.pop(0)
 
-    if verb in ('installed', 'not-installed'):
-        if not arguments:
-            raise ValueError("Package name missing: %r" % expression)
-        if len(arguments) > 1:
-            raise ValueError("Only one package allowed: %r" % expression)
-
-        try:
-            __import__(arguments[0])
-            installed = True
-        except ImportError:
-            installed = False
-
-        if verb == 'installed':
-            return installed
-        elif verb == 'not-installed':
-            return not installed
-    else:
+    if verb not in ('installed', 'not-installed'):
         raise ValueError("Invalid import condition: %r" % expression)
+
+    if not arguments:
+        raise ValueError("Package name missing: %r" % expression)
+    if len(arguments) > 1:
+        raise ValueError("Only one package allowed: %r" % expression)
+
+    try:
+        __import__(arguments[0])
+        installed = True
+    except ImportError:
+        installed = False
+
+    if verb == 'installed':
+        return installed
+    elif verb == 'not-installed':
+        return not installed
 
 
 def shouldPurgeList(value_node, key):

--- a/plone/app/registry/exportimport/handler.py
+++ b/plone/app/registry/exportimport/handler.py
@@ -23,6 +23,36 @@ from plone.supermodel.utils import prettyXML, elementToValue, valueToElement, ns
 _marker = object()
 
 
+def evaluateCondition(expression):
+    """Evaluate import condition.
+
+    ``expression`` is a string of the form "verb arguments".
+
+    Currently the supported verbs are ``installed`` and ``not-installed``.
+    """
+    arguments = expression.split(None)
+    verb = arguments.pop(0)
+
+    if verb in ('installed', 'not-installed'):
+        if not arguments:
+            raise ValueError("Package name missing: %r" % expression)
+        if len(arguments) > 1:
+            raise ValueError("Only one package allowed: %r" % expression)
+
+        try:
+            __import__(arguments[0])
+            installed = True
+        except ImportError:
+            installed = False
+
+        if verb == 'installed':
+            return installed
+        elif verb == 'not-installed':
+            return not installed
+    else:
+        raise ValueError("Invalid import condition: %r" % expression)
+
+
 def shouldPurgeList(value_node, key):
     for child in value_node:
         attrib = child.attrib
@@ -87,6 +117,9 @@ class RegistryImporter(object):
 
         for node in tree:
             if not isinstance(node.tag, str):
+                continue
+            condition = node.attrib.get('condition', None)
+            if condition and not evaluateCondition(condition):
                 continue
             if node.tag.lower() == 'record':
                 self.importRecord(node)

--- a/plone/app/registry/exportimport/handler.py
+++ b/plone/app/registry/exportimport/handler.py
@@ -20,6 +20,9 @@ from plone.supermodel.debug import parseinfo
 
 from plone.supermodel.utils import prettyXML, elementToValue, valueToElement, ns
 
+from zope.configuration import config
+from zope.configuration import xmlconfig
+
 _marker = object()
 
 
@@ -28,29 +31,20 @@ def evaluateCondition(expression):
 
     ``expression`` is a string of the form "verb arguments".
 
-    Currently the supported verbs are ``installed`` and ``not-installed``.
+    Currently the supported verbs are 'have', 'not-have',
+    'installed' and 'not-installed'.
+
+    The 'have' verb takes one argument: the name of a feature.
     """
-    arguments = expression.split(None)
-    verb = arguments.pop(0)
-
-    if verb not in ('installed', 'not-installed'):
-        raise ValueError("Invalid import condition: %r" % expression)
-
-    if not arguments:
-        raise ValueError("Package name missing: %r" % expression)
-    if len(arguments) > 1:
-        raise ValueError("Only one package allowed: %r" % expression)
-
     try:
-        __import__(arguments[0])
-        installed = True
+        import Zope2.App.zcml
+        context = Zope2.App.zcml._context or config.ConfigurationMachine()
     except ImportError:
-        installed = False
+        context = config.ConfigurationMachine()
 
-    if verb == 'installed':
-        return installed
-    elif verb == 'not-installed':
-        return not installed
+    handler = xmlconfig.ConfigurationHandler(context)
+    return handler.evaluateCondition(expression)
+
 
 
 def shouldPurgeList(value_node, key):

--- a/plone/app/registry/tests/test_exportimport.py
+++ b/plone/app/registry/tests/test_exportimport.py
@@ -316,17 +316,6 @@ class TestImport(ExportImportTest):
 
         self.assertRaises(ImportError, importRegistry, context)
 
-    def test_import_records_nonexistant_interface_condition_skip(self):
-        xml = """\
-<registry>
-    <records interface="non.existant.ISchema"
-             condition="installed non" />
-</registry>
-"""
-        context = DummyImportContext(self.site, purge=False)
-        context._files = {'registry.xml': xml}
-        importRegistry(context)
-
     def test_import_value_only(self):
         xml = """\
 <registry>
@@ -344,8 +333,41 @@ class TestImport(ExportImportTest):
         importRegistry(context)
 
         self.assertEquals(1, len(self.registry.records))
-        self.assertEquals(u"Simple record", self.registry.records['test.export.simple'].field.title)
-        self.assertEquals(u"Imported value", self.registry['test.export.simple'])
+        self.assertEquals(
+            u"Simple record",
+            self.registry.records['test.export.simple'].field.title
+        )
+        self.assertEquals(
+            u"Imported value",
+            self.registry['test.export.simple']
+        )
+
+    def test_import_value_only_condition_skip(self):
+        xml = """\
+<registry>
+    <record name="test.export.simple"
+            condition="installed non">
+        <value>Imported value</value>
+    </record>
+</registry>
+"""
+        context = DummyImportContext(self.site, purge=False)
+        context._files = {'registry.xml': xml}
+
+        self.registry.records['test.export.simple'] = \
+            Record(field.TextLine(title=u"Simple record", default=u"N/A"),
+                   value=u"Sample value")
+        importRegistry(context)
+
+        self.assertEquals(1, len(self.registry.records))
+        self.assertEquals(
+            u"Simple record",
+            self.registry.records['test.export.simple'].field.title
+        )
+        self.assertEquals(
+            u"Sample value",
+            self.registry['test.export.simple']
+        )
 
     def test_import_interface_and_value(self):
         xml = """\

--- a/plone/app/registry/tests/test_exportimport.py
+++ b/plone/app/registry/tests/test_exportimport.py
@@ -293,6 +293,40 @@ class TestImport(ExportImportTest):
         self.assertEqual(self.registry['plone.app.registry.tests.data.SomethingElse.name'], 'Magic')
         self.assertEqual(self.registry['plone.app.registry.tests.data.SomethingElse.age'], 42)
 
+    def test_import_records_nonexistant_interface(self):
+        xml = """\
+<registry>
+    <records interface="non.existant.ISchema" />
+</registry>
+"""
+        context = DummyImportContext(self.site, purge=False)
+        context._files = {'registry.xml': xml}
+
+        self.assertRaises(ImportError, importRegistry, context)
+
+    def test_import_records_nonexistant_interface_condition(self):
+        xml = """\
+<registry>
+    <records interface="non.existant.ISchema"
+             condition="not-installed non" />
+</registry>
+"""
+        context = DummyImportContext(self.site, purge=False)
+        context._files = {'registry.xml': xml}
+
+        self.assertRaises(ImportError, importRegistry, context)
+
+    def test_import_records_nonexistant_interface_condition_skip(self):
+        xml = """\
+<registry>
+    <records interface="non.existant.ISchema"
+             condition="installed non" />
+</registry>
+"""
+        context = DummyImportContext(self.site, purge=False)
+        context._files = {'registry.xml': xml}
+        importRegistry(context)
+
     def test_import_value_only(self):
         xml = """\
 <registry>


### PR DESCRIPTION
Because https://github.com/plone/Products.CMFPlone/issues/1406 was supposed to help add-ons staying compatible with Plone 4.3.x, but plone.app.registry README discourages installing > 1.2.x on Plone 4.3.x.