### PR TITLE
added a pragmatic XML exporter for registry records

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,8 @@ Breaking changes:
 
 New features:
 
-- *add item here*
+- Added a pragmatic XML exporter for registry records in a format meant to be used in add-ons or policy profiles.
+  [jensens]
 
 Bug fixes:
 

--- a/plone/app/registry/browser/configure.zcml
+++ b/plone/app/registry/browser/configure.zcml
@@ -6,6 +6,11 @@
     <include package="plone.app.z3cform" />
     <include package="plone.autoform" />
 
+    <browser:resourceDirectory
+        name="plone.app.registry"
+        directory="resources"
+        />
+
     <browser:defaultView
         for="plone.registry.interfaces.IRegistry"
         name="configuration_registry"
@@ -34,9 +39,11 @@
         permission="cmf.ManagePortal"
         />
 
-    <browser:resourceDirectory
-        name="plone.app.registry"
-        directory="resources"
+    <browser:page
+        for="plone.registry.interfaces.IRegistry"
+        name="configuration_registry_export_xml"
+        class=".exportxml.RegistryExporterView"
+        permission="cmf.ManagePortal"
         />
 
 </configure>

--- a/plone/app/registry/browser/exportxml.py
+++ b/plone/app/registry/browser/exportxml.py
@@ -1,0 +1,138 @@
+# -*- coding: utf-8 -*-
+from lxml import etree
+from plone.registry.interfaces import IRegistry
+from Products.Five import BrowserView
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from zope.component import getUtility
+
+import os
+
+_current_dir = os.path.dirname(__file__)
+
+
+def _sort_first_lower(key):
+    return key[0].lower()
+
+
+class RegistryExporterView(BrowserView):
+    """this view make sane exports of the registry.
+
+    Main goal is to export in a way, that the output can be reused as
+    best practive settings
+    """
+
+    template = ViewPageTemplateFile(
+        os.path.join(_current_dir, 'templates', 'exportxml.pt')
+    )
+
+    def __call__(self):
+        interface = self.request.form.get('interface', None)
+        name = self.request.form.get('name', None)
+        if not interface and not name:
+            return self.template()
+        return self.export(sinterface=interface, sname=name)
+
+    def interfaces(self):
+        prefixes = []
+        registry = getUtility(IRegistry)
+        baseurl = '{0}/@@configuration_registry_export_xml?interface='.format(
+            self.context.absolute_url()
+        )
+        for record in registry.records.values():
+            if record.interfaceName is None:
+                continue
+            name = record.interfaceName
+            url = '{0}{1}'.format(baseurl, record.interfaceName)
+            pair = (name, url)
+            if pair not in prefixes:
+                prefixes.append(pair)
+
+        return sorted(prefixes, key=_sort_first_lower)
+
+    def prefixes(self):
+        prefixes = []
+        registry = getUtility(IRegistry)
+        baseurl = '{0}/@@configuration_registry_export_xml?'.format(
+            self.context.absolute_url()
+        )
+        for record in registry.records.values():
+            if record.interfaceName == record.__name__:
+                continue
+
+            def add_split(part):
+                url = '{0}name={1}'.format(baseurl, part)
+                pair = (part, url)
+                if pair not in prefixes:
+                    prefixes.append(pair)
+                if part.rfind('/') > part.rfind('.'):
+                    new_parts = part.rsplit('/', 1)
+                else:
+                    new_parts = part.rsplit('.', 1)
+                if len(new_parts) > 1:
+                    add_split(new_parts[0])
+
+            add_split(record.__name__)
+        return sorted(prefixes, key=_sort_first_lower)
+
+    def export(self, sinterface=None, sname=None):
+        registry = getUtility(IRegistry)
+        root = etree.Element('registry')
+        values = {}  # full prefix to valuerecord
+        interface2values = {}
+        interface2prefix = {}
+        for record in registry.records.values():
+            if sinterface and sinterface != record.interfaceName:
+                continue
+            if sname and not record.__name__.startswith(sname):
+                continue
+            prefix, value_key = record.__name__.rsplit('.', 1)
+            xmlvalue = etree.Element('value')
+            if record.value is None:
+                continue
+            if isinstance(record.value, (list, tuple)):
+                for element in record.value:
+                    xmlel = etree.SubElement(xmlvalue, 'element')
+                    xmlel.text = element
+            elif isinstance(record.value, bool):
+                xmlvalue.text = 'True' if record.value else 'False'
+            elif isinstance(record.value, basestring):
+                xmlvalue.text = record.value
+            else:
+                xmlvalue.text = str(record.value)
+
+            if record.interfaceName:
+                xmlvalue.attrib['key'] = value_key
+                if record.interfaceName not in interface2values:
+                    interface2values[record.interfaceName] = []
+                interface2values[record.interfaceName].append(record.__name__)
+                interface2prefix[record.interfaceName] = prefix
+            values[record.__name__] = xmlvalue
+
+        for ifname in sorted(interface2values):
+            xmlrecord = etree.SubElement(root, 'records')
+            xmlrecord.attrib['interface'] = ifname
+            xmlrecord.attrib['prefix'] = interface2prefix[ifname]
+            for value in sorted(interface2values[ifname]):
+                xmlrecord.append(values.pop(value))
+        for name, xmlvalue in values.items():
+            xmlrecord = etree.SubElement(root, 'records')
+            xmlrecord.attrib['prefix'] = name
+            xmlrecord.append(xmlvalue)
+
+        self.request.response.setHeader('Content-Type', 'text/xml')
+        filename = ''
+        if sinterface:
+            filename += sinterface
+        if sinterface and sname:
+            filename += '_-_'
+        if sname:
+            filename += sname
+        self.request.response.setHeader(
+            'Content-Disposition',
+            'attachment; filename={0}.xml'.format(filename))
+        return etree.tostring(
+            root,
+            pretty_print=True,
+            xml_declaration=True,
+            encoding='UTF-8'
+        )

--- a/plone/app/registry/browser/templates/exportxml.pt
+++ b/plone/app/registry/browser/templates/exportxml.pt
@@ -1,0 +1,25 @@
+<tal>
+    <h3 i18n:translate="registry_export_parts_heading">Export parts</h3>
+    <p i18n:translate="registry_export_parts_text">
+      Download of a XML-file optimized to be used in a GenericSetup profile of an add-on or policy profile.
+      It contains only the selected parts.
+    </p>
+
+    <div class="pat-autotoc autotabs"
+         data-pat-autotoc="levels: h3; section: div.exporttab; className: autotabs">
+        <div class="exporttab"
+             id="export-section-interfaces">
+          <h3 i18n:translate="registry_export_parts_label_iface" id="h3-interfaces">by Interface</h3>
+          <ul class="collapse_interfaces hidden">
+            <li tal:repeat="prefix python:view.interfaces()"><a target="_blank" href="${python:prefix[1]}">${python:prefix[0]}</a></li>
+          </ul>
+        </div>
+        <div class="exporttab"
+             id="export-section-prefixes">
+          <h3 i18n:translate="registry_export_parts_label_prefix" id="h3-prefixes">by Prefix</h3>
+          <ul>
+            <li tal:repeat="prefix python:view.prefixes()"><a target="_blank" href="${python:prefix[1]}">${python:prefix[0]}</a></li>
+          </ul>
+        </div>
+    </div>
+</tal>

--- a/plone/app/registry/browser/templates/records.pt
+++ b/plone/app/registry/browser/templates/records.pt
@@ -132,6 +132,8 @@
               <button type="submit" i18n:translate="export_button">Export Now</button>
             </div>
           </form>
+          <hr />
+          <div tal:replace="structure python:context.restrictedTraverse('@@configuration_registry_export_xml')()" />
         </div>
         <div class="tab">
           <h2 i18n:translate="import">Import</h2>


### PR DESCRIPTION
This enhancement plans to fulfill the 80% need for those working with policy packages all the time.
It exports a part of the registry in a friendly way, so it can be used in the policy package of a project.

- Adds a Button "Export" to the registry control-panel.
- Opens an overlay showing 2 tabs: "by Interface" and "by prefix".
- Under each tab are all interfaces or all prefixes (including parent prefixes) listed.
- clicking on an interface or prefix export the selected part ready to be used in an custom profile

![screenshot from 2017-03-03 12 51 42](https://cloud.githubusercontent.com/assets/157140/23550228/3e54950c-0010-11e7-89e1-bba37a125ef4.png)

An exported snippet looks like so for an Interface 
``Products.CMFPlone.interfaces.controlpanel.ILanguageSchema.xml``: 

```
<?xml version='1.0' encoding='UTF-8'?>
<registry>
  <records interface="Products.CMFPlone.interfaces.controlpanel.ILanguageSchema" prefix="plone">
    <value key="always_show_selector">False</value>
    <value key="authenticated_users_only">False</value>
    <value key="available_languages">
      <element>en-us</element>
    </value>
    <value key="default_language">en-us</value>
    <value key="display_flags">False</value>
    <value key="set_cookie_always">False</value>
    <value key="use_cctld_negotiation">False</value>
    <value key="use_combined_language_codes">True</value>
    <value key="use_content_negotiation">False</value>
    <value key="use_cookie_negotiation">False</value>
    <value key="use_path_negotiation">False</value>
    <value key="use_request_negotiation">False</value>
    <value key="use_subdomain_negotiation">False</value>
  </records>
</registry>
```

and looks like so for an single prefix:
``plone.allowed_sizes.xml``

```
<?xml version='1.0' encoding='UTF-8'?>
<registry>
  <records interface="Products.CMFPlone.interfaces.controlpanel.IImagingSchema" prefix="plone">
    <value key="allowed_sizes">
      <element>large 768:768</element>
      <element>preview 400:400</element>
      <element>mini 200:200</element>
      <element>thumb 128:128</element>
      <element>tile 64:64</element>
      <element>icon 32:32</element>
      <element>listing 16:16</element>
    </value>
  </records>
</registry>
```

and looks like so for a prefix subtree:
``plone.app.caching.moderateCaching.xml``

```
<?xml version='1.0' encoding='UTF-8'?>
<registry>
  <records prefix="plone.app.caching.moderateCaching.ramCache">
    <value>False</value>
  </records>
  <records prefix="plone.app.caching.moderateCaching.smaxage">
    <value>86400</value>
  </records>
  <records prefix="plone.app.caching.moderateCaching.anonOnly">
    <value>False</value>
  </records>
  <records prefix="plone.app.caching.moderateCaching.etags">
    <value/>
  </records>
  <records prefix="plone.app.caching.moderateCaching.lastModified">
    <value>False</value>
  </records>
</registry>
```



