### PR TITLE
[Plone 5.2] Fix an issue that was preventing the edit of a registry record containing a "/" in its name

### DIFF
--- a/news/51.bugfix
+++ b/news/51.bugfix
@@ -1,0 +1,1 @@
+Fix an issue that was preventing the edit of a registry record containing a "/" in its name [ale-rt]

--- a/plone/app/registry/browser/edit.py
+++ b/plone/app/registry/browser/edit.py
@@ -16,6 +16,13 @@ class RecordEditForm(form.EditForm):
 
     record = None
 
+    @property
+    def action(self):
+        return "{}/edit/{}".format(
+            self.context.absolute_url(),
+            self.record.__name__,
+        )
+
     def getContent(self):
         return ImplicitAcquisitionWrapper(
             {'value': self.record.value},


### PR DESCRIPTION
Backport of #52 for Plone 5.2 

Refs #51
Refs plone/Products.CMFPlone#3296