### PR TITLE
Fix responsive table

### DIFF
--- a/news/64.bugfix
+++ b/news/64.bugfix
@@ -1,0 +1,2 @@
+Fix responsive table.
+[petschki]

--- a/plone/app/registry/browser/templates/records.pt
+++ b/plone/app/registry/browser/templates/records.pt
@@ -88,7 +88,8 @@
 
             </div>
 
-          <table class="table table-responsive table-bordered table-striped">
+          <div class="table-responsive">
+          <table class="table table-bordered table-striped">
               <thead>
                   <tr>
                       <th i18n:translate="heading_name">Name</th>
@@ -135,6 +136,7 @@
                   </tr>
               </tfoot>
           </table>
+          </div>
         </div>
         </div>
         <div class="tab">


### PR DESCRIPTION
if there are long record values (eg. logo or favicon) the table is now scrolling horizontally without breaking the outer layout