### PR TITLE
Remove duplicate "content" id

### DIFF
--- a/news/84.bugfix
+++ b/news/84.bugfix
@@ -1,0 +1,2 @@
+Removes duplicate `<article id="content">`
+[@szakitibi]

--- a/plone/app/registry/browser/templates/records.pt
+++ b/plone/app/registry/browser/templates/records.pt
@@ -17,11 +17,10 @@
   </metal:block>
 
   <body>
-    <metal:main
-             metal:fill-slot="prefs_configlet_main"
-             tal:define="
-               records view/records;
-             "
+    <metal:main metal:fill-slot="prefs_configlet_main"
+                tal:define="
+                  records view/records;
+                "
     >
 
       <header>

--- a/plone/app/registry/browser/templates/records.pt
+++ b/plone/app/registry/browser/templates/records.pt
@@ -17,7 +17,7 @@
   </metal:block>
 
   <body>
-    <article id="content"
+    <metal:main
              metal:fill-slot="prefs_configlet_main"
              tal:define="
                records view/records;
@@ -251,6 +251,6 @@
           </div>
         </div>
       </div>
-    </article>
+    </metal:main>
   </body>
 </html>


### PR DESCRIPTION
There is a duplicate `<article id="content"`>` introduced with the controlpanel.
https://github.com/plone/plone.app.registry/blob/2ffffe69324cc480081e99b1e9553c160ec61d7b/plone/app/registry/browser/templates/records.pt#L20-L25

The `main_template.pt` already has one - see https://github.com/plone/Products.CMFPlone/blob/6.0.11/Products/CMFPlone/browser/templates/main_template.pt#L85.

As a result there is two `<article id="content">` for `portal_registry` controlpanel - view source for https://classic.demo.plone.org/portal_registry.

The problem can be eliminated by changing the id, or using a simple metal tag to fill the slot. 