### PR TITLE
Fix misleading portal message

### DIFF
--- a/news/+ignore.bugfix
+++ b/news/+ignore.bugfix
@@ -1,0 +1,1 @@
+Fix misleading portal message when NOT deleting records @gforcada

--- a/plone/app/registry/browser/delete.py
+++ b/plone/app/registry/browser/delete.py
@@ -15,6 +15,6 @@ class RecordDeleteView(BrowserView):
                     messages.add("Successfully deleted field %s" % name, type="info")
             elif self.request.form.get("form.buttons.cancel") and name:
                 messages = IStatusMessage(self.request)
-                messages.add("Successfully deleted field %s" % name, type="info")
+                messages.add("Field %s was not deleted" % name, type="info")
             return self.request.response.redirect(self.context.absolute_url())
         return super().__call__()


### PR DESCRIPTION
Probably a copy and paste error?

But that's a scary one! When you cancel the deleting, it still says that it deleted it!